### PR TITLE
Allow 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,4 +15,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Arpack = "^0.5"
 FinEtools = "^5"
-julia = "^1.7"
+julia = "^1.6"


### PR DESCRIPTION
I noticed your thread on discourse and your change in compat to:
```
julia = "^1.7"
```

I think it rules out 1.6 (for no good reason?), and you don't want that. I'm not sure, maybe you need to also change the version too with this PR.

You did upgrade to "1.1.0", could have gone to ""1.0.2" is seems while you may have wanted the former anyway.

In case you think Julia 1.6 still worked then yes, because then it would get the older version of your package, and it might be a hard-to-debug situation for many. Unless you know you're using features from later Julia versions, I would recommend being as little restrictive as possible.